### PR TITLE
Add a note in the readme about needing PHP >= 5.3

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,15 @@ One-click WordPress plugin that converts all posts, pages, taxonomies, metadata,
 
 [![Build Status](https://travis-ci.org/benbalter/wordpress-to-jekyll-exporter.svg?branch=master)](https://travis-ci.org/benbalter/wordpress-to-jekyll-exporter)
 
+A Note 
+------
+
+Many shared hosts may use PHP 5.2 by default. WordPress to Jekyll Export requires PHP 5.3 or greater.
+
+PHP 5.2 lost support from the PHP project itself more than three years ago. You'll need to be running at least PHP 5.3 which adds namespace support (the reason it's breaking), but I'd recommend at least 5.4 (or the latest your host supports) as it's the oldest supported version: https://en.wikipedia.org/wiki/PHP#Release_history
+
+In a shared hosting environment, you should be able to change the version of PHP used by toggling the setting in the host's control panel.
+
 Features
 --------
 


### PR DESCRIPTION
cc https://github.com/benbalter/wordpress-to-jekyll-exporter/issues/23, https://github.com/benbalter/wordpress-to-jekyll-exporter/issues/28, https://github.com/benbalter/wordpress-to-jekyll-exporter/issues/29, https://github.com/benbalter/wordpress-to-jekyll-exporter/issues/33, and  https://github.com/benbalter/wordpress-to-jekyll-exporter/issues/40