### PR TITLE
Include date in frontmatter

### DIFF
--- a/jekyll-exporter.php
+++ b/jekyll-exporter.php
@@ -103,6 +103,7 @@ class Jekyll_Export {
     $output = array(
       'id'      => $post->ID,
       'title'   => get_the_title( $post ),
+      'date'    => get_the_date( 'c', $post ),
       'author'  => get_userdata( $post->post_author )->display_name,
       'excerpt' => $post->post_excerpt,
       'layout'  => get_post_type( $post ),

--- a/tests/test-wordpress-to-jekyll-exporter.php
+++ b/tests/test-wordpress-to-jekyll-exporter.php
@@ -70,6 +70,7 @@ class WordPressToJekyllExporterTest extends WP_UnitTestCase {
     $expected = Array (
       'id'        => $post->ID,
       'title'     => 'Test Post',
+      'date'      => '2014-01-01T00:00:00+00:00',
       'author'    => 'Tester',
       'excerpt'   => '',
       'layout'    => 'post',


### PR DESCRIPTION
This allows the order of posts to be preserved when there are multiples per day.  ISO 8601 is not strictly the format specified by Jekyll (which [says](http://jekyllrb.com/docs/frontmatter/#predefined-variables-for-posts) `YYYY-MM-DD HH:MM:SS +/-TTTT`), but it does work.