### PR TITLE
Add buffering on export to prevent output corruption

### DIFF
--- a/jekyll-exporter.php
+++ b/jekyll-exporter.php
@@ -328,11 +328,13 @@ class Jekyll_Export {
 	 */
 	function export() {
 		do_action( 'jekyll_export' );
+		ob_start();
 		$this->init_temp_dir();
 		$this->convert_options();
 		$this->convert_posts();
 		$this->convert_uploads();
 		$this->zip();
+		ob_end_clean();
 		$this->send();
 		$this->cleanup();
 	}


### PR DESCRIPTION
Adapted from this pull request from the pico exporter after getting corrupt zip files using WP 4.8

https://github.com/tomzx/wordpress-to-pico-exporter/commit/3c8867a8373ce9c5ac216099c94cea440d616d60