### PR TITLE
Export drafts

### DIFF
--- a/jekyll-exporter.php
+++ b/jekyll-exporter.php
@@ -403,8 +403,7 @@ class Jekyll_Export {
 
 		if ( get_post_status( $post ) !== 'publish' ) {
 			$filename = '_drafts/' . sanitize_file_name( get_page_uri( $post->id ) . '-' . ( get_the_title( $post->id ) ) . '.md' );
-		}
-		elseif ( get_post_type( $post ) === 'page' ) {
+		} elseif ( get_post_type( $post ) === 'page' ) {
 			$filename = get_page_uri( $post->id ) . '.md';
 		} else {
 			$filename = '_' . get_post_type( $post ) . 's/' . date( 'Y-m-d', strtotime( $post->post_date ) ) . '-' . sanitize_file_name( $post->post_name ) . '.md';

--- a/jekyll-exporter.php
+++ b/jekyll-exporter.php
@@ -400,17 +400,17 @@ class Jekyll_Export {
 	function write( $output, $post ) {
 
 		global $wp_filesystem;
-	
-		if (get_post_status($post) !== 'publish') {
-			$filename = '_drafts/' . sanitize_file_name(get_page_uri( $post->id ) . '-' . (get_the_title($post->id)) . '.md');
+
+		if ( get_post_status( $post ) !== 'publish' ) {
+			$filename = '_drafts/' . sanitize_file_name( get_page_uri( $post->id ) . '-' . ( get_the_title( $post->id ) ) . '.md' );
 		}
-		else if ( get_post_type( $post ) === 'page' ) {
+		elseif ( get_post_type( $post ) === 'page' ) {
 			$filename = get_page_uri( $post->id ) . '.md';
 		} else {
-			$filename = '_' . get_post_type( $post ) . 's/' . date( 'Y-m-d', strtotime( $post->post_date ) ) . '-' . sanitize_file_name($post->post_name) . '.md';
+			$filename = '_' . get_post_type( $post ) . 's/' . date( 'Y-m-d', strtotime( $post->post_date ) ) . '-' . sanitize_file_name( $post->post_name ) . '.md';
 		}
 
-		$wp_filesystem->mkdir( $this->dir . dirname($filename) );
+		$wp_filesystem->mkdir( $this->dir . dirname( $filename ) );
 		$wp_filesystem->put_contents( $this->dir . $filename, $output );
 	}
 

--- a/script/cibuild
+++ b/script/cibuild
@@ -2,6 +2,9 @@
 
 set -e
 
+echo "Verifying mysql is up..."
+pgrep mysql > /dev/null || sudo service mysql start 
+
 export PATH="$HOME/.composer/vendor/bin:./bin:$PATH"
 
 echo "Running unit tests..."

--- a/tests/test-wordpress-to-jekyll-exporter.php
+++ b/tests/test-wordpress-to-jekyll-exporter.php
@@ -9,8 +9,6 @@
  * @link       https://github.com/benbalter/wordpress-to-jekyll-exporter/
  */
 
-use Alchemy\Zippy\Zippy;
-
 /**
  * Test suite for JekyllExport
  */
@@ -35,41 +33,44 @@ class WordPressToJekyllExporterTest extends WP_UnitTestCase {
 			)
 		);
 
-		wp_insert_post(
-			array(
-				'post_name'     => 'test-post',
-				'post_title'    => 'Test Post',
-				'post_content'  => 'This is a test <strong>post</strong>.',
-				'post_status'   => 'publish',
-				'post_author'   => $author,
-				'post_category' => array( $category_id ),
-				'tags_input'    => array( 'tag1', 'tag2' ),
-				'post_date'     => '2014-01-01',
-			)
-		);
+		if ( count( get_posts() ) === 0 ) {
 
-		$page_id = wp_insert_post(
-			array(
-				'post_name'    => 'test-page',
-				'post_title'   => 'Test Page',
-				'post_content' => 'This is a test <strong>page</strong>.',
-				'post_status'  => 'publish',
-				'post_type'    => 'page',
-				'post_author'  => $author,
-			)
-		);
+			wp_insert_post(
+				array(
+					'post_name'     => 'test-post',
+					'post_title'    => 'Test Post',
+					'post_content'  => 'This is a test <strong>post</strong>.',
+					'post_status'   => 'publish',
+					'post_author'   => $author,
+					'post_category' => array( $category_id ),
+					'tags_input'    => array( 'tag1', 'tag2' ),
+					'post_date'     => '2014-01-01',
+				)
+			);
 
-		wp_insert_post(
-			array(
-				'post_name'    => 'sub-page',
-				'post_title'   => 'Sub Page',
-				'post_content' => 'This is a test <strong>sub</strong> page.',
-				'post_status'  => 'publish',
-				'post_type'    => 'page',
-				'post_parent'  => $page_id,
-				'post_author'  => $author,
-			)
-		);
+			$page_id = wp_insert_post(
+				array(
+					'post_name'    => 'test-page',
+					'post_title'   => 'Test Page',
+					'post_content' => 'This is a test <strong>page</strong>.',
+					'post_status'  => 'publish',
+					'post_type'    => 'page',
+					'post_author'  => $author,
+				)
+			);
+
+			wp_insert_post(
+				array(
+					'post_name'    => 'sub-page',
+					'post_title'   => 'Sub Page',
+					'post_content' => 'This is a test <strong>sub</strong> page.',
+					'post_status'  => 'publish',
+					'post_type'    => 'page',
+					'post_parent'  => $page_id,
+					'post_author'  => $author,
+				)
+			);
+		}
 
 		global $jekyll_export;
 		$jekyll_export->init_temp_dir();
@@ -108,7 +109,7 @@ class WordPressToJekyllExporterTest extends WP_UnitTestCase {
 	 */
 	function test_gets_post_ids() {
 		global $jekyll_export;
-		$this->assertEquals( 9, count( $jekyll_export->get_posts() ) );
+		$this->assertEquals( 3, count( $jekyll_export->get_posts() ) );
 	}
 
 	/**

--- a/tests/test-wordpress-to-jekyll-exporter.php
+++ b/tests/test-wordpress-to-jekyll-exporter.php
@@ -9,16 +9,45 @@
  * @link       https://github.com/benbalter/wordpress-to-jekyll-exporter/
  */
 
-/**
- * Test suite for JekyllExport
- */
+ /**
+  * Test suite for JekyllExport
+  */
 class WordPressToJekyllExporterTest extends WP_UnitTestCase {
 
 	/**
-	 * Setup the test suite
+	 * ID of sample post
+	 *
+	 * @var int
 	 */
-	function setUp() {
-		parent::setUp();
+	private static $post_id = 0;
+
+	/**
+	 * ID of sample draft
+	 *
+	 * @var int
+	 */
+	private static $draft_id = 0;
+
+	/**
+	 * ID of sample page
+	 *
+	 * @var int
+	 */
+	private static $page_id = 0;
+
+	/**
+	 * ID of sample sub-page
+	 *
+	 * @var int
+	 */
+	private static $sub_page_id = 0;
+
+	/**
+	 * Setup the test class
+	 */
+	static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
 		$author = wp_insert_user(
 			array(
 				'user_login'   => rand_str(),
@@ -33,48 +62,64 @@ class WordPressToJekyllExporterTest extends WP_UnitTestCase {
 			)
 		);
 
-		if ( count( get_posts() ) === 0 ) {
+		self::$post_id = wp_insert_post(
+			array(
+				'post_name'     => 'test-post',
+				'post_title'    => 'Test Post',
+				'post_content'  => 'This is a test <strong>post</strong>.',
+				'post_status'   => 'publish',
+				'post_author'   => $author,
+				'post_category' => array( $category_id ),
+				'tags_input'    => array( 'tag1', 'tag2' ),
+				'post_date'     => '2014-01-01',
+			)
+		);
 
-			wp_insert_post(
-				array(
-					'post_name'     => 'test-post',
-					'post_title'    => 'Test Post',
-					'post_content'  => 'This is a test <strong>post</strong>.',
-					'post_status'   => 'publish',
-					'post_author'   => $author,
-					'post_category' => array( $category_id ),
-					'tags_input'    => array( 'tag1', 'tag2' ),
-					'post_date'     => '2014-01-01',
-				)
-			);
+		self::$draft_id = wp_insert_post(
+			array(
+				'post_name'     => 'test-draft',
+				'post_title'    => 'Test Draft',
+				'post_content'  => 'This is a test <strong>draft</strong>.',
+				'post_status'   => 'draft',
+				'post_author'   => $author,
+				'post_category' => array( $category_id ),
+				'tags_input'    => array( 'tag1', 'tag2' ),
+				'post_date'     => '2014-01-01',
+			)
+		);
 
-			$page_id = wp_insert_post(
-				array(
-					'post_name'    => 'test-page',
-					'post_title'   => 'Test Page',
-					'post_content' => 'This is a test <strong>page</strong>.',
-					'post_status'  => 'publish',
-					'post_type'    => 'page',
-					'post_author'  => $author,
-				)
-			);
+		self::$page_id = wp_insert_post(
+			array(
+				'post_name'    => 'test-page',
+				'post_title'   => 'Test Page',
+				'post_content' => 'This is a test <strong>page</strong>.',
+				'post_status'  => 'publish',
+				'post_type'    => 'page',
+				'post_author'  => $author,
+			)
+		);
 
-			wp_insert_post(
-				array(
-					'post_name'    => 'sub-page',
-					'post_title'   => 'Sub Page',
-					'post_content' => 'This is a test <strong>sub</strong> page.',
-					'post_status'  => 'publish',
-					'post_type'    => 'page',
-					'post_parent'  => $page_id,
-					'post_author'  => $author,
-				)
-			);
-		}
+		self::$sub_page_id = wp_insert_post(
+			array(
+				'post_name'    => 'sub-page',
+				'post_title'   => 'Sub Page',
+				'post_content' => 'This is a test <strong>sub</strong> page.',
+				'post_status'  => 'publish',
+				'post_type'    => 'page',
+				'post_parent'  => self::$page_id,
+				'post_author'  => $author,
+			)
+		);
+	}
+
+	/**
+	 * Setup the test suite
+	 */
+	function setUp() {
+		parent::setUp();
 
 		global $jekyll_export;
 		$jekyll_export->init_temp_dir();
-
 	}
 
 	/**
@@ -109,7 +154,9 @@ class WordPressToJekyllExporterTest extends WP_UnitTestCase {
 	 */
 	function test_gets_post_ids() {
 		global $jekyll_export;
-		$this->assertEquals( 3, count( $jekyll_export->get_posts() ) );
+		$expected = array( self::$post_id, self::$draft_id, self::$page_id, self::$sub_page_id );
+		$actual = $jekyll_export->get_posts();
+		$this->assertTrue( ! array_diff( $expected, $actual ) && ! array_diff( $actual, $expected ) );
 	}
 
 	/**
@@ -117,8 +164,7 @@ class WordPressToJekyllExporterTest extends WP_UnitTestCase {
 	 */
 	function test_convert_meta() {
 		global $jekyll_export;
-		$posts = $jekyll_export->get_posts();
-		$post = get_post( $posts[0] );
+		$post = get_post( self::$post_id );
 		$meta = $jekyll_export->convert_meta( $post );
 		$expected = array(
 			'id'        => $post->ID,
@@ -138,9 +184,7 @@ class WordPressToJekyllExporterTest extends WP_UnitTestCase {
 	 */
 	function test_convert_terms() {
 		global $jekyll_export;
-		$posts = $jekyll_export->get_posts();
-		$post = get_post( $posts[0] );
-		$terms = $jekyll_export->convert_terms( $post->ID );
+		$terms = $jekyll_export->convert_terms( self::$post_id );
 		$this->assertEquals(
 			array(
 				0 => 'Testing',
@@ -159,8 +203,7 @@ class WordPressToJekyllExporterTest extends WP_UnitTestCase {
 	 */
 	function test_convert_content() {
 		global $jekyll_export;
-		$posts = $jekyll_export->get_posts();
-		$post = get_post( $posts[0] );
+		$post = get_post( self::$post_id );
 		$content = $jekyll_export->convert_content( $post );
 		$this->assertEquals( 'This is a test **post**.', $content );
 	}
@@ -179,25 +222,25 @@ class WordPressToJekyllExporterTest extends WP_UnitTestCase {
 	 */
 	function test_convert_posts() {
 		global $jekyll_export;
-		$posts = $jekyll_export->convert_posts();
+		$jekyll_export->convert_posts();
 		$post = $jekyll_export->dir . '/_posts/2014-01-01-test-post.md';
 
 		// write the file to the temp dir.
-		$this->assertTrue( file_exists( $post ) );
+		$this->assertFileExists( $post );
 
 		// Handles pages.
-		$this->assertTrue( file_exists( $jekyll_export->dir . 'test-page.md' ) );
-		$this->assertTrue( file_exists( $jekyll_export->dir . 'test-page/sub-page.md' ) );
+		$this->assertFileExists( $jekyll_export->dir . 'test-page.md' );
+		$this->assertFileExists( $jekyll_export->dir . 'test-page/sub-page.md' );
 
 		// writes the file contents.
 		$contents = file_get_contents( $post );
-		$this->assertContains( 'title: Test Post', $contents );
+		$this->assertContains( 'title: Test Post', $contents, 'file contents' );
 
 		// writes valid YAML.
 		$parts = explode( '---', $contents );
-		$this->assertEquals( 3,count( $parts ) );
+		$this->assertEquals( 3, count( $parts ), 'Invalid YAML Front Matter' );
 		$yaml = spyc_load( $parts[1] );
-		$this->assertNotEmpty( $yaml );
+		$this->assertNotEmpty( $yaml, 'Empty YAML' );
 
 		// writes the front matter.
 		$this->assertEquals( 'Test Post', $yaml['title'] );
@@ -247,8 +290,7 @@ class WordPressToJekyllExporterTest extends WP_UnitTestCase {
 	 */
 	function test_write() {
 		global $jekyll_export;
-		$posts = $jekyll_export->get_posts();
-		$post = get_post( $posts[0] );
+		$post = get_post( self::$post_id );
 		$jekyll_export->write( 'Foo', $post );
 		$post = $jekyll_export->dir . '/_posts/2014-01-01-test-post.md';
 		$this->assertTrue( file_exists( $post ) );

--- a/tests/test-wordpress-to-jekyll-exporter.php
+++ b/tests/test-wordpress-to-jekyll-exporter.php
@@ -223,14 +223,18 @@ class WordPressToJekyllExporterTest extends WP_UnitTestCase {
 	function test_convert_posts() {
 		global $jekyll_export;
 		$jekyll_export->convert_posts();
+
 		$post = $jekyll_export->dir . '/_posts/2014-01-01-test-post.md';
 
-		// write the file to the temp dir.
+		// write the post file to the temp dir.
 		$this->assertFileExists( $post );
 
 		// Handles pages.
 		$this->assertFileExists( $jekyll_export->dir . 'test-page.md' );
 		$this->assertFileExists( $jekyll_export->dir . 'test-page/sub-page.md' );
+
+		// Handles drafts.
+		$this->assertFileExists( $jekyll_export->dir . '/_drafts/test-draft-Test-Draft.md' );
 
 		// writes the file contents.
 		$contents = file_get_contents( $post );


### PR DESCRIPTION
Addresses https://github.com/benbalter/wordpress-to-jekyll-exporter/issues/107.

The draft filenames can come out a bit too verbose but seeing as some revision objects have strange properties (like no id) I felt it better to err on the side of safety so drafts aren't overridden and lost.

**Verified on:**
Azure Web App (IIS on Windows)
PHP 5.6
Project Nami (WordPress on MS SQL Server) 4.8.1
Twenty Sixteen Theme 1.3
Site: https://www.ohadsoft.com