### PR TITLE
Stop parser from dropping <iframe> tags

### DIFF
--- a/vendor/pixel418/markdownify/src/Converter.php
+++ b/vendor/pixel418/markdownify/src/Converter.php
@@ -150,7 +150,7 @@ class Converter
         'area',
         'object',
         'param',
-        'iframe',
+//        'iframe',
     );
 
     /**


### PR DESCRIPTION
I'm not sure if you want this or not, but this one-line fix will stop **Markdownify** from discarding `<iframe>` tags.

This is different then the hack proposed in #52 (I was unable to get that working).