### PR TITLE
Replace changelog with releases link

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -27,7 +27,7 @@ License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
 See [the full documentation](https://ben.balter.com/wordpress-to-jekyll-exporter):
 
-* [Changelog](changelog.md)
+* [Changelog](https://github.com/benbalter/wordpress-to-jekyll-exporter/releases)
 * [Command-line-usage](command-line-usage.md)
 * [Custom post types](custom-post-types.md)
 * [Developing locally](developing-locally.md)


### PR DESCRIPTION
That's what `docs/changelog.md` links to. Could also link to `docs/changelog.md` instead if you prefer...

I guess this file should be called` .md` and not `.txt` as it contains markdown rather than plain text, but I could be wrong about that. I guess `.txt` works as the content is rendered as markdown...