### PR TITLE
Fix more information links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,8 +26,8 @@ View plugin in [the WordPress plugin directory](https://wordpress.org/plugins/je
 
 See [the full documentation](https://ben.balter.com/wordpress-to-jekyll-exporter):
 
-* [Changelog](changelog.md)
-* [Command-line-usage](command-line-usage.md)
-* [Custom post types](custom-post-types.md)
-* [Developing locally](developing-locally.md)
-* [Minimum required PHP version](required-php-version.md)
+* [Changelog](/docs/changelog.md)
+* [Command-line-usage](/docs/command-line-usage.md)
+* [Custom post types](/docs/custom-post-types.md)
+* [Developing locally](/docs/developing-locally.md)
+* [Minimum required PHP version](/docs/required-php-version.md)


### PR DESCRIPTION
Fix more information links so that they don't '404' when clicked from repository home page.