### PR TITLE
removed file.php include from cli

### DIFF
--- a/jekyll-export-cli.php
+++ b/jekyll-export-cli.php
@@ -17,7 +17,6 @@
  * Must be run in the wordpress-to-jekyll-exporter/ directory.
  */
 require '../../../wp-load.php';
-require '../../../wp-admin/includes/file.php';
 require_once 'jekyll-exporter.php'; // Ensure plugin is "activated".
 
 if ( php_sapi_name() !== 'cli' ) {


### PR DESCRIPTION
## When running `php jekyll-export-cli.php` the CLI failed with an error stating that `file.php` was already included.

```bash
wp-content/plugins/jekyll-exporter# php jekyll-export-cli.php
PHP Fatal error:  Cannot redeclare get_file_description() (previously declared in /var/www/html/wp/wp-admin/includes/file.php:79) in /var/www/html/wp/wp-admin/includes/file.php on line 96

Fatal error: Cannot redeclare get_file_description() (previously declared in /var/www/html/wp/wp-admin/includes/file.php:79) in /var/www/html/wp/wp-admin/includes/file.php on line 96
```

## Removing the `file.php` include from the cli allowed the script to work correctly.