### PR TITLE
update documentation links to work on github.com and locally

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,8 +28,8 @@ View plugin in [the WordPress plugin directory](https://wordpress.org/plugins/je
 
 See [the full documentation](https://ben.balter.com/wordpress-to-jekyll-exporter):
 
-* [Changelog](./changelog.md)
-* [Command-line-usage](./command-line-usage.md)
-* [Custom post types](./custom-post-types.md)
-* [Developing locally](./developing-locally.md)
-* [Minimum required PHP version](./required-php-version.md)
+* [Changelog](../docs/changelog.md)
+* [Command-line-usage](../docs/command-line-usage.md)
+* [Custom post types](../docs/custom-post-types.md)
+* [Developing locally](../docs/developing-locally.md)
+* [Minimum required PHP version](../docs/required-php-version.md)


### PR DESCRIPTION
Hello! 👋🏽 First off, thank you for sharing this utility! I've used it on my journey to convert my personal site from Wordpress to Jekyll.

If was not made aware, the documentation links at the bottom of the README 404 when clicking on them from github.com's site.

![image](https://user-images.githubusercontent.com/577057/180269868-03e8083c-38a3-4227-84bc-6d4fd14e1f4f.png)

This PR addresses that and does it in a manner that will still work when trying the links under a local dev environment.