### PR TITLE
Export future posts to _posts

### DIFF
--- a/jekyll-exporter.php
+++ b/jekyll-exporter.php
@@ -391,7 +391,7 @@ class Jekyll_Export {
 
 		global $wp_filesystem;
 
-		if ( get_post_status( $post ) !== 'publish' ) {
+		if ( ! in_array( get_post_status( $post ), array( 'publish', 'future' ), true ) ) {
 			$filename = '_drafts/' . sanitize_file_name( get_page_uri( $post->id ) . '-' . ( get_the_title( $post->id ) ) . '.md' );
 		} elseif ( get_post_type( $post ) === 'page' ) {
 			$filename = get_page_uri( $post->id ) . '.md';


### PR DESCRIPTION
Jekyll won't publish posts with a future date by default, matching the Wordpress behaviour.

Source: https://jekyllrb.com/docs/configuration/options/ (search for "--future").

~~Edit: marked as draft because it's missing the tests.~~