### PR TITLE
Various improvements (see PR)

### DIFF
--- a/jekyll-export-cli.php
+++ b/jekyll-export-cli.php
@@ -16,12 +16,54 @@
  *
  * Must be run in the wordpress-to-jekyll-exporter/ directory.
  */
-require '../../../wp-load.php';
+
+// Uncomment for extra replace options
+
+$wordpress_path = "../../../";
+//$wordpress_path = "/home/wordpress/";
+
+require $wordpress_path . 'wp-load.php';
 require_once 'jekyll-exporter.php'; // Ensure plugin is "activated".
+
+$config["site_url"] = "https://www.mywebsite.fr/";
+
+$config["extra_remove_site_url"] = $config["site_url"];  // Will remove site url to get relative URLs
+$config['extra_code'] = true; // Will retrieve lang and protect pre/code
+$config['extra_img_style'] = true; // Will retrieve style from image
+$config['extra_tag_spoiler'] = true; // Will convert spoiler tags
+
+//$config['force_dest_dir'] = "/dest-path/"; // "_export/"; // Force destination directory to relative one (without temp folder, will deactivate zip)
+
 
 if ( php_sapi_name() !== 'cli' ) {
 	wp_die( 'Jekyll export must be run via the command line or administrative dashboard.' );
 }
+
+add_filter( 'the_content', function($contents) {
+	
+	if ($config["extra_remove_site_url"]) $contents = preg_replace("!${$config['extra_remove_site_url']}!",'', $contents);
+
+	if ($config['extra_code']) {
+		$contents = preg_replace('!<span[^>]*crayon-inline[^>]*>([^<]*)</span>!','<code>\1</code>', $contents);
+		$contents = preg_replace('!class="lang:default!','class="', $contents);
+		$contents = preg_replace('!class="lang:!','class="language-', $contents);
+		$contents = preg_replace('!<pre([^>]*)><code>!','<pre\1>', $contents);
+		$contents = preg_replace('!</code></pre>!','</pre>', $contents);
+		$contents = preg_replace('!<pre([^>]*)>!','<pre><code \1>', $contents);
+		$contents = preg_replace('!</pre[^>]*>!','</code></pre>', $contents);
+	}
+	if ($config['extra_img_style']) {
+		$contents = preg_replace('!(<img[^>]*alignright[^>]*/>)!','\1{: .img-right}', $contents);
+		$contents = preg_replace('!(<img[^>]*aligncenter[^>]*/>)!','\1{: .img-center}', $contents);
+		$contents = preg_replace('!(<img[^>]*aligncenter[^>]*/>)!','\1{: .img-center}', $contents);
+	}
+	if ($config['extra_tag_spoiler']) {
+		$contents = preg_replace('!\[su_spoiler title="([^"]*)" [^\]]*\]!',"<details markdown=\"1\"><summary>\\1</summary>", $contents);
+		$contents = preg_replace('!\[/su_spoiler\]!',"</details>", $contents);
+	}
+								
+	return $contents;
+});
 
 $jekyll_export = new Jekyll_Export();
 $jekyll_export->export();

--- a/jekyll-exporter.php
+++ b/jekyll-exporter.php
@@ -35,6 +35,32 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+// Extra options
+
+$config = array();
+
+// $config["site_url"] = "https://mywebsite.fr/"; // Destination site URL
+// $config['force_dest_dir'] = "_export/"; // Force destination directory to relative one (without temp folder, will deactivate zip)
+
+$config['forceHtml'] = false; // true;	// Force export to HTML
+
+// Skip some parts of the script that you do not need
+// $config['skip_options'] = true; 
+// $config['skip_posts'] = true; 
+// $config['skip_uploads'] = true; 
+// $config['skip_comments'] = true; 
+
+$config['comment_target_data'] = true;		// Export comments as data files
+// $config['comment_target_pages'] = true;	// Export comments as jekyll pages
+// $config['comment_target_github'] = true; // Export comments to GitHub discussions (for use with Giscus)
+
+// To export comments to GitHub for Giscus (https://giscus.app)
+// $config['gh_token'] = "gho_xxxx";					 // Get token from command line: gh auth token 
+// $config['gh_repo'] = "R_kgDOIVZ3BQ";				 // Get values from giscus config page
+// $config['category_id'] = "DIC_kwDOIVZ3Bc4CSRMx"; // Get values from giscus config page
+
+
+
 if ( version_compare( PHP_VERSION, '5.3.0', '<' ) ) {
 	wp_die( 'Jekyll Export requires PHP 5.3 or later' );
 }
@@ -46,6 +72,102 @@ use League\HTMLToMarkdown\HtmlConverter;
 use League\HTMLToMarkdown\Converter\TableConverter;
 use Symfony\Component\Yaml\Yaml;
 
+
+// https://gist.github.com/dunglas/05d901cb7560d2667d999875322e690a
+function graphql_query(string $endpoint, string $query, array $variables = [], ?string $token = null): array
+{
+    $headers = ['Content-Type: application/json', 'User-Agent: Dunglas\'s minimal GraphQL client'];
+    if (null !== $token) {
+        $headers[] = "Authorization: bearer $token";
+    }
+
+    if (false === $data = @file_get_contents($endpoint, false, stream_context_create([
+        'http' => [
+            'method' => 'POST',
+            'header' => $headers,
+            'content' => json_encode(['query' => $query, 'variables' => $variables]),
+        ]
+    ]))) {
+        $error = error_get_last();
+        throw new \ErrorException($error['message'], $error['type']);
+    }
+
+    return json_decode($data, true);
+}
+
+
+function github_query(string $query, array $variables = []) {
+	global $config;
+	$ret = null;
+	if ($config['gh_token']) { 
+		$ret = graphql_query('https://api.github.com/graphql', $query, $variables, $config['gh_token']);
+		sleep(5);	// Delay because Github does not like mutations too quick
+	}
+	return $ret;
+}
+
+
+function gh_create_discussion($title, $content) {
+	global $config;
+
+	$query = <<<'GRAPHQL'
+		mutation MyMutation($repositoryId: ID!, $title: String!, $body: String!, $categoryId: ID!) { 
+			createDiscussion(input: {
+				repositoryId: $repositoryId, 
+				title: $title, 
+				body: $body, 
+				categoryId: $categoryId
+			}) 
+		{ discussion {  id  } } }
+		GRAPHQL;
+
+	$vars = [
+		'repositoryId' => $config['gh_repo'], 
+		'title' => $title, 
+		'body' => $content, 
+		'categoryId' => $config['category_id']
+	];
+
+	$r = github_query($query, $vars);
+
+	$discussion_id = $r['data']['createDiscussion']['discussion']['id'] ?? null;
+	
+	if ($discussion_id == null) { var_dump(">>> Discussion", $query, $vars, $r, $discussion_id); }
+
+	return $discussion_id;
+}
+
+
+function gh_create_discussion_comment($discussionId, $content, $parent_comment = null) {
+	global $config;
+
+	$query = <<<'GRAPHQL'
+				mutation MyMutation($discussionId: ID!, $body: String!, $replyToId: ID ) {
+					addDiscussionComment(
+					input: {
+						discussionId: $discussionId, 
+						body: $body, 
+						replyToId: $replyToId
+					}) 
+					{ comment { id }}
+				}
+		GRAPHQL;
+
+	$vars = [
+		'discussionId' => $discussionId, 
+		'body' => $content, 
+		'replyToId' => $parent_comment
+	];
+	
+	$r = github_query($query, $vars);
+
+	$comment_id = $r['data']['addDiscussionComment']['comment']['id'] ?? null;
+
+	//if (!$comment_id) { var_dump(">> Comment", $query, $vars, $r); }
+
+	return $comment_id;
+}
+
 /**
  * Class Jekyll_Export
  *
@@ -56,6 +178,9 @@ use Symfony\Component\Yaml\Yaml;
  * @link       https://github.com/benbalter/wordpress-to-jekyll-exporter/
  */
 class Jekyll_Export {
+
+	public $gh_discussions = array(); // wordpress id => github id
+	public $gh_comments = array(); // wordpress id => github id
 
 	/**
 	 * Strings to strip from option keys on export
@@ -125,7 +250,7 @@ class Jekyll_Export {
 		}
 
 		$posts      = array();
-		$post_types = apply_filters( 'jekyll_export_post_types', array( 'post', 'page', 'revision' ) );
+		$post_types = apply_filters( 'jekyll_export_post_types', array( 'post', 'page' /*, 'revision'*/ ) );
 
 		/**
 		 * WordPress style rules don't let us interpolate a string before passing it to
@@ -149,28 +274,43 @@ class Jekyll_Export {
 	function convert_meta( $post ) {
 
 		$output = array(
-			'id'      => $post->ID,
+			'post_id'      => $post->ID,
 			'title'   => get_the_title( $post ),
 			'date'    => get_the_date( 'c', $post ),
+			'last_modified_at'    => get_the_modified_date( 'c', $post ),
 			'author'  => get_userdata( $post->post_author )->display_name,
 			'excerpt' => $post->post_excerpt,
 			'layout'  => get_post_type( $post ),
 			'guid'    => $post->guid,
+			'slug'   => $post->post_name,
 		);
 
 		// Preserve exact permalink, since Jekyll doesn't support redirection.
-		if ( 'page' !== $post->post_type ) {
+		$ignore_permalink = array(); // array('page')
+		if ( !in_array($post->post_type, $ignore_permalink) ) {
 			$output['permalink'] = str_replace( home_url(), '', get_permalink( $post ) );
 		}
 
 		// Convert traditional post_meta values, hide hidden values.
+		$ignore_list = array(
+			'_*',
+			'ocean_*',
+			'classic-editor-remember',
+			'osh_disable_topbar_sticky',
+			'osh_disable_header_sticky',
+			'osh_sticky_header_style',
+			'ampforwp-amp-on-off',
+		);
+
 		foreach ( get_post_custom( $post->ID ) as $key => $value ) {
 
-			if ( substr( $key, 0, 1 ) === '_' ) {
-				continue;
+			$ignore = false;
+			foreach ($ignore_list as $ignore_item) {
+				if (fnmatch($ignore_item, $key)) { $ignore = true; }
 			}
 
-			$output[ $key ] = $value;
+			if (is_array($value) && (count($value) == 1)) { $value = $value[0]; }
+			if (!$ignore) $output[ $key ] = $value;
 		}
 
 		$post_thumbnail_id = get_post_thumbnail_id( $post );
@@ -198,27 +338,66 @@ class Jekyll_Export {
 
 		$output = array();
 		foreach ( get_taxonomies(
-			array(
+			/*array(
 				'object_type' => array( get_post_type( $post ) ),
-			)
+			)*/
 		) as $tax ) {
 
 			$terms = get_the_terms( $post, $tax );
 
-			// Convert tax name for Jekyll.
-			switch ( $tax ) {
-				case 'post_tag':
-					$tax = 'tags';
-					break;
-				case 'category':
-					$tax = 'categories';
-					break;
-			}
+			if ($terms != false) {
+				// Convert tax name for Jekyll.
+				switch ( $tax ) {
+					case 'post_tag':
+						$tax = 'tags';
+						break;
+					case 'category':
+						$tax = 'categories';
+						foreach ($terms as $key => $value) {
+							$tr_tax = wp_get_object_terms($value->term_id, 'term_translations');
+							$translations = unserialize($tr_tax[0]->description);
+							$cat_fr_id = $translations['fr'];
+							if ($cat_fr_id > 0) { 
+								$cat_fr = get_term($cat_fr_id + 0);
+								$terms[$key] = $cat_fr;
+							}
+						}
+						break;
+					
+					// Extract Polylang
+					case 'language':
+						$tax = 'lang';
+						if (count($terms) == 1) {
+							$terms = str_replace('pll_','', $terms[0]->slug);
+						}
+						break;
+					case 'post_language':
+						$tax = 'lang';
+						if (count($terms) == 1) {
+							$terms = str_replace('pll_','', $terms[0]->slug);
+						}
+						break;
+					case 'post_translations':
+						$tax = 'lang-translations';
+						if (count($terms) == 1) {
+							$output['lang-ref'] = $terms[0]->name;
+							$translations = unserialize($terms[0]->description);
+							foreach ($translations as $key => $value) {
+								$tr_post = get_post($value + 0);
+								$translations[$key] = $tr_post->post_name;
+							}
+							$terms = $translations;
+						}
+						break;
+				}
 
-			if ( 'post_format' === $tax ) {
-				$output['format'] = get_post_format( $post );
-			} elseif ( is_array( $terms ) ) {
-				$output[ $tax ] = wp_list_pluck( $terms, 'name' );
+				if ( 'post_format' === $tax ) {
+					$output['format'] = get_post_format( $post );
+				} elseif ( is_array( $terms ) && ($tax != 'lang-translations')) {
+					$output[ $tax ] = wp_list_pluck( $terms, 'name' );
+				} else {
+					$output[ $tax ] = $terms;
+				}
 			}
 		}
 
@@ -232,8 +411,8 @@ class Jekyll_Export {
 	 * @param Post $post the post to Convert.
 	 * @return String the converted post content
 	 */
-	function convert_content( $post ) {
-
+	function convert_content( $post_content ) {
+		/*
 		// check if jetpack markdown is available.
 		if ( class_exists( 'WPCom_Markdown' ) ) {
 			$wpcom_markdown_instance = WPCom_Markdown::get_instance();
@@ -245,15 +424,18 @@ class Jekyll_Export {
 				return $content;
 			}
 		}
+		*/
 
-		$content           = apply_filters( 'the_content', $post->post_content );
+		global $config;
+
+		$content           = apply_filters( 'the_content', $post_content );
 		$converter_options = apply_filters( 'jekyll_export_markdown_converter_options', array( 'header_style' => 'atx' ) );
 		$converter         = new HtmlConverter( $converter_options );
 		$converter->getEnvironment()->addConverter( new TableConverter() );
 
 		$markdown = $converter->convert( $content );
 
-		if ( strpos( $markdown, '[]: ' ) !== false ) {
+		if ( ( strpos( $markdown, '[]: ' ) !== false) || ($config['forceHtml']) ) {
 			// faulty links; return plain HTML.
 			$content = apply_filters( 'jekyll_export_html', $content );
 			$content = apply_filters( 'jekyll_export_content', $content );
@@ -269,11 +451,14 @@ class Jekyll_Export {
 	 * Loop through and convert all posts to MD files with YAML headers
 	 */
 	function convert_posts() {
-		global $post;
-
-		foreach ( $this->get_posts() as $post_id ) {
+		//global $post;  // was causing the issue, php was mixing posts
+		
+		foreach (  $this->get_posts() as $post_id ) {
 			$post = get_post( $post_id );
+
 			setup_postdata( $post );
+
+			//if ($post->ID != $post_id)  var_dump($post);
 
 			$meta = array_merge( $this->convert_meta( $post ), $this->convert_terms( $post_id ) );
 
@@ -284,11 +469,176 @@ class Jekyll_Export {
 				}
 			}
 
+			$content = $post->post_content;
+
 			$output  = "---\n";
 			$output .= Yaml::dump( $meta );
 			$output .= "---\n\n";
-			$output .= $this->convert_content( $post );
+			$output .= $this->convert_content( $content );
 			$this->write( $output, $post );
+		}
+	}
+
+	function convert_comment_github($header, $content, $post, $comment) {
+		global $config;
+
+		$post_id = $post->ID;
+
+		// Need to get meta of post
+		$meta = array_merge( $this->convert_meta( $post ), $this->convert_terms( $post_id ) );
+
+		// Create discussion if not already created (TODO: search github instead of cache)
+		if (!array_key_exists($post_id, $this->gh_discussions)) {
+			$discussion_id = gh_create_discussion($meta['permalink'],
+				get_the_excerpt($post) . "\n\n" .
+				$config["site_url"] . $meta['permalink']);
+			$this->gh_discussions[$post_id] = $discussion_id;
+		}
+
+		// Get parent comment id (TODO: search github instead of cache)
+		$comment_parent_id = null;
+		if ($comment->comment_parent != '0') {
+			if (array_key_exists($comment->comment_parent, $this->gh_comments)) {
+				$comment_parent_id = $this->gh_comments[$comment->comment_parent];
+			} else {
+				// parent comment should have been created before, not normal
+				printf("Parent comment not found:" . $comment->comment_parent);
+			}
+		}
+
+
+		$migrated_text = "_From **{$comment->comment_author}** on **{$comment->comment_date}** (Migrated from Wordpress):_\n\n";
+		// Basic multilang comment support (fr only)
+		if ($meta['lang'] == 'fr') $migrated_text = "_De **{$comment->comment_author}** le **{$comment->comment_date}** (Migré depuis Wordpress):_\n\n";
+		
+		$comment_id = gh_create_discussion_comment(
+			$this->gh_discussions[$post_id],
+			"<!-- WordPress ID: \n$header -->\n" . $migrated_text . 	$content, 
+			$comment_parent_id
+		);
+		$this->gh_comments[$comment->comment_ID] = $comment_id;
+	}
+
+	/**
+	 * Loop through and convert all comments to MD files with YAML headers
+	 */
+
+	function convert_comment($post, $comment) {
+		global $config;
+
+		$comment_meta =  array(
+			'comment_ID'      => $comment->comment_ID,
+			'comment_author'      => $comment->comment_author,
+			'comment_author_url'      => $comment->comment_author_url,
+			'comment_date'      => $comment->comment_date, // = '0000-00-00 00:00:00';
+			'comment_date_gmt'      => $comment->comment_date_gmt, // = '0000-00-00 00:00:00';
+			'comment_type'      => $comment->comment_type,
+			'comment_parent'      => $comment->comment_parent,
+			'post_id'      => $post->ID,
+			// Other comments metadata available (warning you may expose personal data)
+			// 'comment_author_email'      => $comment->comment_author_email,
+			// 'comment_author_IP'      => $comment->comment_author_IP,
+			// 'comment_karma'      => $comment->comment_karma,
+			// 'comment_approved'      => $comment->comment_approved,
+			// 'comment_agent'      => $comment->comment_agent,
+			// 'user_id'      => $user_id,
+		);
+		
+		$header   = "---\n";
+		$header .= Yaml::dump( $comment_meta );
+		$header .= "---\n\n";
+
+		$content = $this->convert_content( $comment->comment_content );
+
+		if ($config['comment_target_github']) {
+			$this->convert_comment_github($header, $content, $post, $comment);
+		}
+
+		if ($config['comment_target_pages']) {
+			$this->write($header . $content, $post, $comment);
+		}
+
+		$this->convert_comment_children($post, $comment->comment_ID);
+	}
+
+	function convert_comment_children($post, $comment_parent) {
+
+		$comments = get_comments(array(
+			'post_id' =>  $post->ID, 
+			'type' => 'comment', 
+			'parent' => $comment_parent,
+			'orderby'=>'comment_date',
+            'order'=>'ASC' 
+		));
+
+		foreach( $comments as $comment ) {
+			$this->convert_comment($post, $comment);
+		}
+
+	}
+
+	function convert_comment_data($post) {
+
+		global $wp_filesystem;
+
+		$comments = get_comments(array(
+			'post_id' =>  $post->ID, 
+			'type' => 'comment', 
+			'orderby'=>'comment_date',
+            'order'=>'ASC' 
+		));
+
+		$comments_list = [];
+
+		foreach( $comments as $comment ) {
+			$comment_data = [
+				'ID'      => $comment->comment_ID,
+				'post_id'      => $post->ID,
+				'author'      => $comment->comment_author,
+				'date'      => $comment->comment_date, // = '0000-00-00 00:00:00';
+			];
+			$comment_data['comment'] =  $comment->comment_content;
+			if ($comment->comment_parent) $comment_data['parent'] = $comment->comment_parent;
+			if ($comment->comment_author_url) $comment_data['author_url'] = $comment->comment_author_url;
+
+			$comments_list[] = $comment_data;
+		}
+
+		if (count($comments_list) > 0) {
+
+			$filename = '_data/comments/' . $post->post_name . '.yml';
+
+			$output = Yaml::dump( $comments_list );
+
+			$wp_filesystem->put_contents( $this->dir . $filename,  $output);		
+		}
+
+	}
+
+
+	function convert_comments() {
+		global $wp_filesystem;
+		global $config;
+
+		//global $post;  // was causing the issue, php was mixing posts
+
+		$ext = ($config['forceHtml']) ? '.html' : '.md';
+
+		$gql = '';
+		
+		foreach (  $this->get_posts() as $post_id ) {
+			$post = get_post( $post_id );
+			setup_postdata( $post );
+
+			// Convert to pages & github
+			if ($config['comment_target_pages'] || $config['comment_target_github']) {
+				$this->convert_comment_children($post, '0');
+			}
+
+			// Convert to data
+			if ($config['comment_target_data']) {
+				$this->convert_comment_data($post);
+			}
 		}
 	}
 
@@ -304,6 +654,7 @@ class Jekyll_Export {
 	 */
 	function init_temp_dir() {
 		global $wp_filesystem;
+		global $config;
 
 		add_filter( 'filesystem_method', array( &$this, 'filesystem_method_filter' ) );
 
@@ -311,33 +662,50 @@ class Jekyll_Export {
 
 		// When on Azure Web App use %HOME%\temp\ to avoid weird default temp folder behavior.
 		// For more information see https://github.com/projectkudu/kudu/wiki/Understanding-the-Azure-App-Service-file-system.
+		
 		$temp_dir = ( getenv( 'WEBSITE_SITE_NAME' ) !== false ) ? ( getenv( 'HOME' ) . DIRECTORY_SEPARATOR . 'temp' ) : get_temp_dir();
 		$wp_filesystem->mkdir( $temp_dir );
 		$temp_dir = realpath( $temp_dir ) . DIRECTORY_SEPARATOR;
 
 		$this->dir = $temp_dir . 'wp-jekyll-' . md5( time() ) . DIRECTORY_SEPARATOR;
+		if ($config['force_dest_dir']) $this->dir = $config['force_dest_dir']; 
 		$this->zip = $temp_dir . 'wp-jekyll.zip';
 
 		$wp_filesystem->mkdir( $this->dir );
 		$wp_filesystem->mkdir( $this->dir . '_posts/' );
+		$wp_filesystem->mkdir( $this->dir . '_pages/' );
 		$wp_filesystem->mkdir( $this->dir . '_drafts/' );
-		$wp_filesystem->mkdir( $this->dir . 'wp-content/' );
+		//$wp_filesystem->mkdir( $this->dir . 'wp-content/' );
+		if ($config['comment_target_pages']) {
+			$wp_filesystem->mkdir( $this->dir . '_comments/' );
+			$wp_filesystem->mkdir( $this->dir . '_comments/_posts/' );
+			$wp_filesystem->mkdir( $this->dir . '_comments/_pages/' );
+		}
+		if ($config['comment_target_data']) {
+			$wp_filesystem->mkdir( $this->dir . '_data/' );
+			$wp_filesystem->mkdir( $this->dir . '_data/comments/' );
+		}
 	}
 
 	/**
 	 * Main function, bootstraps, converts, and cleans up
 	 */
 	function export() {
+		global $config;
+
 		do_action( 'jekyll_export' );
 		ob_start();
 		$this->init_temp_dir();
-		$this->convert_options();
-		$this->convert_posts();
-		$this->convert_uploads();
-		$this->zip();
+		if (!$config['skip_options']) $this->convert_options();
+		if (!$config['skip_posts']) $this->convert_posts();
+		if (!$config['skip_uploads']) $this->convert_uploads();
+		if (!$config['skip_comments']) $this->convert_comments();
 		ob_end_clean();
-		$this->send();
-		$this->cleanup();
+		if (!$config['force_dest_dir']) {
+			$this->zip();
+			$this->send();
+			$this->cleanup();
+		}
 	}
 
 
@@ -387,20 +755,33 @@ class Jekyll_Export {
 	 * @param String $output the post content.
 	 * @param Post   $post the Post object.
 	 */
-	function write( $output, $post ) {
+	function write( $output, $post, $comment = null ) {
 
 		global $wp_filesystem;
+		global $config;
 
-		if ( ! in_array( get_post_status( $post ), array( 'publish', 'future' ), true ) ) {
-			$filename = '_drafts/' . sanitize_file_name( get_page_uri( $post->id ) . '-' . ( get_the_title( $post->id ) ) . '.md' );
+		$ext = ($config['forceHtml']) ? '.html' : '.md';
+
+		if ( get_post_type( $post ) === 'revision' ) {
+			$filename = '_revisions/' . sanitize_file_name( get_page_uri( $post ) . '-' . ( get_the_title( $post ) ) );
+		} elseif ( ! in_array( get_post_status( $post ), array( 'publish', 'future' ), true ) ) {
+			$filename = '_drafts/' . sanitize_file_name( get_page_uri( $post ) . '-' . ( get_the_title( $post ) ) );
 		} elseif ( get_post_type( $post ) === 'page' ) {
-			$filename = get_page_uri( $post->id ) . '.md';
+			$filename = '_pages/' . get_page_uri( $post );
 		} else {
-			$filename = '_' . get_post_type( $post ) . 's/' . gmdate( 'Y-m-d', strtotime( $post->post_date ) ) . '-' . sanitize_file_name( $post->post_name ) . '.md';
+			$filename = '_' . get_post_type( $post ) . 's/' . gmdate( 'Y-m-d', strtotime( $post->post_date ) ) . '-' . sanitize_file_name( $post->post_name );
 		}
 
 		$wp_filesystem->mkdir( $this->dir . dirname( $filename ) );
-		$wp_filesystem->put_contents( $this->dir . $filename, $output );
+
+		if ($comment) {
+			$filename = "_comments/" . $filename;
+			$wp_filesystem->mkdir( $this->dir . dirname( $filename ) );
+			$filename = $filename . '/' . gmdate( 'Y-m-d', strtotime( $comment->comment_date ) ) . '-' . sanitize_file_name( $comment->comment_type ) . '-' . $comment->comment_ID  . '-' . sanitize_file_name( $comment->comment_author );
+			$wp_filesystem->mkdir( $this->dir . dirname( $filename ) );
+		}
+
+		$wp_filesystem->put_contents( $this->dir . $filename . $ext, $output );
 	}
 
 	/**


### PR DESCRIPTION
Hello,

Thanks for your plugin that was very useful to me for my Jekyll migration from WordPress. 

I have made some customizations that may interest some other users:
- added comments export, with three destination possible:
  - as data / collections (to be treated with some liquid)
  - as posts with metadata and markdown as contents
  - as GitHub discussions for use with [Giscus](https://giscus.app)
- added [Polylang](https://polylang.pro/) plugin extraction of languages (and reference to translated pages, and unifying translated categories and tags)
- added some processing to WordPress contents:
  - remove the site host add by WordPress to get relative URI  (useful to test on other hosts before switching)
  - improved code section conversion, specially when using WordPress plugin crayon
  - export image alignment in markdown styles
  - convert spoiler tag to details HTML tag
- added some metadata and filtered useless ones from oceanwp WordPress theme (list is configurable) 
- and various settings to execute the script outside WordPress folders, to skip some parts of the script (useful to speed-up when running multiple times with posts or script modifications), and to generate without zip in a specific folder

Hope these little things can be useful 

Thanks again for the plugin,