### PR TITLE
Added docs for Custom fields

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,5 +31,6 @@ See [the full documentation](https://ben.balter.com/wordpress-to-jekyll-exporter
 * [Changelog](../docs/changelog.md)
 * [Command-line-usage](../docs/command-line-usage.md)
 * [Custom post types](../docs/custom-post-types.md)
+* [Custom fields](../docs/custom-fields.md)
 * [Developing locally](../docs/developing-locally.md)
 * [Minimum required PHP version](../docs/required-php-version.md)

--- a/docs/custom-fields.md
+++ b/docs/custom-fields.md
@@ -37,3 +37,26 @@ add_filter( 'jekyll_export_meta', function($meta) {
     return $meta;
 });
 ```
+
+A more complete solution could look like that:
+
+```php
+add_filter( 'jekyll_export_meta', function($meta) {
+    foreach ($meta as $key => $value) {
+        if (is_array($value) && count($value) === 1 && array_key_exists(0, $value)) {
+            $value = maybe_unserialize($value[0]);
+            if (is_array($value)) {
+                $value = $value[0];
+            }
+        }
+        $meta[$key] = match ($key) {
+            'my-bool' => (bool) $value,
+            default => $value
+        };
+        $meta[$key] = $value;
+    }
+
+    return $meta;
+});
+```
+

--- a/docs/custom-fields.md
+++ b/docs/custom-fields.md
@@ -1,0 +1,39 @@
+## Custom fields
+
+When using custom fields (e.g. with the Advanced Custom fields plugin) you might have to register a filter to convert array style configs to plain values.
+
+By default, the plugin saves custom fields in an array structure that is exported as: 
+
+```php
+["my-bool"]=>
+    array(1) {
+        [0] => string(1) "1"
+    }
+["location"]=>
+    array(1) {
+        [0] => string(88) "My address"
+    }
+```
+
+And this leads to a YAML structure like:
+
+```yaml
+my-bool:
+- "1"
+location:
+- 'My address'
+```
+
+This is likely not the structure you expect or want to work with. You can convert it using a filter:
+
+```php
+add_filter( 'jekyll_export_meta', function($meta) {
+    foreach ($meta as $key => $value) {
+        if (is_array($value) && count($value) === 1 && array_key_exists(0, $value)) {
+            $meta[$key] = $value[0];
+        }
+    }
+
+    return $meta;
+});
+```

--- a/docs/custom-fields.md
+++ b/docs/custom-fields.md
@@ -43,13 +43,16 @@ A more complete solution could look like that:
 ```php
 add_filter( 'jekyll_export_meta', function($meta) {
     foreach ($meta as $key => $value) {
+        // Advanced Custom Fields
         if (is_array($value) && count($value) === 1 && array_key_exists(0, $value)) {
             $value = maybe_unserialize($value[0]);
-            if (is_array($value)) {
+            // Advanced Custom Fields: NextGEN Gallery Field add-on
+            if (is_array($value) && count($value) === 1 && array_key_exists(0, $value)) {
                 $value = $value[0];
             }
         }
         $meta[$key] = match ($key) {
+            // Advanced Custom Fields: "true_false" type
             'my-bool' => (bool) $value,
             default => $value
         };

--- a/docs/custom-fields.md
+++ b/docs/custom-fields.md
@@ -51,7 +51,8 @@ add_filter( 'jekyll_export_meta', function($meta) {
                 $value = $value[0];
             }
         }
-        $meta[$key] = match ($key) {
+        // convert types
+        $value = match ($key) {
             // Advanced Custom Fields: "true_false" type
             'my-bool' => (bool) $value,
             default => $value

--- a/docs/custom-post-types.md
+++ b/docs/custom-post-types.md
@@ -1,10 +1,10 @@
 ## Custom post types
 
-To export custom post types, you'll need to add a filter to do the following:
+To export custom post types, you'll need to add a filter (w.g. to your themes config file) to do the following:
 
 ```php
 add_filter( 'jekyll_export_post_types', function() {
-	return array('posts', 'pages', 'you-custom-post-type');
+	return array('post', 'page', 'you-custom-post-type');
 });
 ```
 


### PR DESCRIPTION
Hey Ben,

thanks for your exporter! Due to the current buzz I am now ready to migrate my last WP site to Jekyll.

Found out that you already have a filter in place to convert custom/meta fields 👍 

I added some documentation, as I was using ACF (Advanced custom fields) a lot, and all fields were stored as array, some (like location field) even as serialized value inside array. 

To save the next person some time, I added this new docs page.

Oh and I fixed the terms of the default content types, I was confused why they stopped working when I added the documented filter.