### PR TITLE
fix passing ID instead of id

### DIFF
--- a/jekyll-exporter.php
+++ b/jekyll-exporter.php
@@ -392,9 +392,9 @@ class Jekyll_Export {
 		global $wp_filesystem;
 
 		if ( ! in_array( get_post_status( $post ), array( 'publish', 'future' ), true ) ) {
-			$filename = '_drafts/' . sanitize_file_name( get_page_uri( $post->id ) . '-' . ( get_the_title( $post->id ) ) . '.md' );
+			$filename = '_drafts/' . sanitize_file_name( get_page_uri( $post->ID ) . '-' . ( get_the_title( $post->ID ) ) . '.md' );
 		} elseif ( get_post_type( $post ) === 'page' ) {
-			$filename = get_page_uri( $post->id ) . '.md';
+			$filename = get_page_uri( $post->ID ) . '.md';
 		} else {
 			$filename = '_' . get_post_type( $post ) . 's/' . gmdate( 'Y-m-d', strtotime( $post->post_date ) ) . '-' . sanitize_file_name( $post->post_name ) . '.md';
 		}


### PR DESCRIPTION
Depending on the PHP version the old code has different outcomes.
In my situation `$post->id` is always an empty string.

The correct field name is `ID`, see https://developer.wordpress.org/reference/classes/wp_post/

As you already use `$post->ID` in other places of the class, this fact is likely not new 😁 